### PR TITLE
Remove 'aspnet' from products list

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ languages:
 products:
 - azure
 - dotnet
-- aspnet
 - aspnet-core
 - azure-app-service
 - vs-code


### PR DESCRIPTION
The `aspnet` value is deprecated.

https://learn.microsoft.com/en-us/help/platform/metadata-taxonomies/product#planned-for-deprecation